### PR TITLE
Add client for artifacts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rake'
 gem 'byebug'
+gem 'rake'
 gem 'rubocop'
 gem 'yard'
 

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -4,6 +4,7 @@ require 'buildkit/client/builds'
 require 'buildkit/client/organizations'
 require 'buildkit/client/pipelines'
 require 'buildkit/client/jobs'
+require 'buildkit/client/artifacts'
 require 'buildkit/response/raise_error'
 
 module Buildkit
@@ -13,6 +14,7 @@ module Buildkit
     include Organizations
     include Pipelines
     include Jobs
+    include Artifacts
 
     DEFAULT_ENDPOINT = 'https://api.buildkite.com/v2/'.freeze
 

--- a/lib/buildkit/client/artifacts.rb
+++ b/lib/buildkit/client/artifacts.rb
@@ -1,0 +1,18 @@
+module Buildkit
+  class Client
+    # Methods for the Artifacts API
+    #
+    # @see https://buildkite.com/docs/api/artifacts
+    module Artifacts
+      # List all artifacts for a build
+      #
+      # @return [Array<Sawyer::Resource>] Array of hashes representing Buildkite artifacts.
+      # @see https://buildkite.com/docs/api/artifacts#list-all-artifacts
+      # @example
+      #   Buildkit.artifacts('my-great-org', 'great-pipeline', 42)
+      def artifacts(org, pipeline, build, options = {})
+        get("/v2/organizations/#{org}/pipelines/#{pipeline}/builds/#{build}/artifacts", options)
+      end
+    end
+  end
+end

--- a/spec/cassettes/artifacts.yml
+++ b/spec/cassettes/artifacts.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/219190/artifacts?per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Buildkit v1.0.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Thu, 12 Jan 2017 20:21:50 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      x-frame-options:
+      - SAMEORIGIN, SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff, nosniff
+      access-control-allow-origin:
+      - "*"
+      access-control-expose-headers:
+      - Link
+      rate-limit-remaining:
+      - '99'
+      rate-limit-limit:
+      - '100'
+      rate-limit-reset:
+      - '10'
+      x-accepted-oauth-scopes:
+      - read_artifacts
+      link:
+      - <https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/219190/artifacts?page=2&per_page=2>;
+        rel="next", <https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/219190/artifacts?page=155&per_page=2>;
+        rel="last"
+      x-oauth-scopes:
+      - read_artifacts,read_builds,read_pipelines
+      etag:
+      - W/"6be063f0a9b79dc3b77a067abca1d700"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 037a230b-43a1-41b7-9dea-120b87d50f16
+      x-runtime:
+      - '0.045727'
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-ua-compatible:
+      - chrome=1
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        [
+          {
+            "id": "2d46bfa3-04d2-4d90-8762-b53366055561",
+            "job_id": "568b1517-c863-44e1-82b7-18a003449d59",
+            "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/219190/jobs/568b1517-c863-44e1-82b7-18a003449d59/artifacts/2d46bfa3-04d2-4d90-8762-b53366055561",
+            "download_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/219190/jobs/568b1517-c863-44e1-82b7-18a003449d59/artifacts/2d46bfa3-04d2-4d90-8762-b53366055561/download",
+            "state": "finished",
+            "path": "lhm.log",
+            "dirname": ".",
+            "filename": "lhm.log",
+            "mime_type": "text/plain",
+            "file_size": 67,
+            "glob_path": "./**/*",
+            "original_path": "/tmp/buildkite-artifacts-20170112-23030-1bhvcb8/lhm.log",
+            "sha1sum": "94eb134b9d1ed0618504b4a9569e99e6913ab196"
+          },
+          {
+            "id": "54ec2688-dc1c-42b0-86f1-5453304be44d",
+            "job_id": "568b1517-c863-44e1-82b7-18a003449d59",
+            "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/219190/jobs/568b1517-c863-44e1-82b7-18a003449d59/artifacts/54ec2688-dc1c-42b0-86f1-5453304be44d",
+            "download_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/219190/jobs/568b1517-c863-44e1-82b7-18a003449d59/artifacts/54ec2688-dc1c-42b0-86f1-5453304be44d/download",
+            "state": "finished",
+            "path": "test.log",
+            "dirname": ".",
+            "filename": "test.log",
+            "mime_type": "text/plain",
+            "file_size": 6923661,
+            "glob_path": "./**/*",
+            "original_path": "/tmp/buildkite-artifacts-20170112-23030-1bhvcb8/test.log",
+            "sha1sum": "9299969df6f3f710117cd575a7d9bd2327b81185"
+          }
+        ]
+    http_version: 
+  recorded_at: Thu, 12 Jan 2017 20:21:50 GMT
+recorded_with: VCR 2.9.3

--- a/spec/client/artifacts_spec.rb
+++ b/spec/client/artifacts_spec.rb
@@ -4,7 +4,7 @@ describe Buildkit::Client::Artifacts do
   context '#artifacts' do
     it 'returns the list of artifacts' do
       VCR.use_cassette 'artifacts' do
-        artifacts = client.artifacts('shopify', 'shopify-branches', 219190, per_page: 2)
+        artifacts = client.artifacts('shopify', 'shopify-branches', 219_190, per_page: 2)
         expect(artifacts.size).to be == 2
 
         artifact = artifacts.first

--- a/spec/client/artifacts_spec.rb
+++ b/spec/client/artifacts_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Buildkit::Client::Artifacts do
+  context '#artifacts' do
+    it 'returns the list of artifacts' do
+      VCR.use_cassette 'artifacts' do
+        artifacts = client.artifacts('shopify', 'shopify-branches', 219190, per_page: 2)
+        expect(artifacts.size).to be == 2
+
+        artifact = artifacts.first
+        expect(artifact.state).to be == 'finished'
+        expect(artifact.path).to be == 'lhm.log'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to retrieve the list of artifacts for a build. Details at https://buildkite.com/docs/rest-api/artifacts

@wvanbergen @Shopify/byroot 
