### PR TITLE
Loosen dependency on sawyer

### DIFF
--- a/buildkit.gemspec
+++ b/buildkit.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_dependency 'sawyer', '~> 0.6.0'
+  spec.add_dependency 'sawyer', '~> 0.6'
   spec.add_development_dependency 'bundler'
 end


### PR DESCRIPTION
Sawyer shipped 0.7.0, 0.8.0 and 0.8.1.
It doesn't look like there have been breaking changes: https://github.com/lostisland/sawyer/compare/v0.6.0...v0.8.1

@casperisfine