### PR TITLE
Add support for getting a job's log output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,13 +7,13 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
 task test: :spec
-task default: [:spec, :rubocop]
+task default: %i[spec rubocop]
 
 namespace :doc do
   require 'yard'
   YARD::Rake::YardocTask.new do |task|
-    task.files = %w(LICENSE.md lib/**/*.rb)
-    task.options = %w(--output-dir doc/yard --markup markdown)
+    task.files = %w[LICENSE.md lib/**/*.rb]
+    task.options = %w[--output-dir doc/yard --markup markdown]
   end
   task default: :yard
 end

--- a/buildkit.gemspec
+++ b/buildkit.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'buildkit/version'

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -19,7 +19,7 @@ module Buildkit
     DEFAULT_ENDPOINT = 'https://api.buildkite.com/v2/'.freeze
 
     # Header keys that can be passed in options hash to {#get},{#head}
-    CONVENIENCE_HEADERS = Set.new([:accept, :content_type])
+    CONVENIENCE_HEADERS = Set.new(%i[accept content_type])
 
     # In Faraday 0.9, Faraday::Builder was renamed to Faraday::RackBuilder
     RACK_BUILDER_CLASS = defined?(Faraday::RackBuilder) ? Faraday::RackBuilder : Faraday::Builder

--- a/lib/buildkit/client/jobs.rb
+++ b/lib/buildkit/client/jobs.rb
@@ -31,6 +31,20 @@ module Buildkit
       def job_env(org, pipeline, build, job, options = {})
         get("/v2/organizations/#{org}/pipelines/#{pipeline}/builds/#{build}/jobs/#{job}/env", options)
       end
+
+      # Get a job's log output
+      #
+      # @param org [String] Organization slug.
+      # @param pipeline [String] Pipeline slug.
+      # @param build [Integer] Build number.
+      # @param job [String] Job id.
+      # @return [Sawyer::Resource] Hash representing the Buildkit job log output.
+      # @see https://buildkite.com/docs/rest-api/jobs#get-a-jobs-log-output
+      # @example
+      #   Buildkit.job_logs('my-great-org', 'great-pipeline', 123, 'my-job-id')
+      def job_log(org, pipeline, build, job, options = {})
+        get("/v2/organizations/#{org}/pipelines/#{pipeline}/builds/#{build}/jobs/#{job}/log", options)
+      end
     end
   end
 end

--- a/lib/buildkit/client/jobs.rb
+++ b/lib/buildkit/client/jobs.rb
@@ -41,7 +41,7 @@ module Buildkit
       # @return [Sawyer::Resource] Hash representing the Buildkit job log output.
       # @see https://buildkite.com/docs/rest-api/jobs#get-a-jobs-log-output
       # @example
-      #   Buildkit.job_logs('my-great-org', 'great-pipeline', 123, 'my-job-id')
+      #   Buildkit.job_log('my-great-org', 'great-pipeline', 123, 'my-job-id')
       def job_log(org, pipeline, build, job, options = {})
         get("/v2/organizations/#{org}/pipelines/#{pipeline}/builds/#{build}/jobs/#{job}/log", options)
       end

--- a/lib/buildkit/error.rb
+++ b/lib/buildkit/error.rb
@@ -105,7 +105,7 @@ module Buildkit
     end
 
     def redact_url(url_string)
-      %w(client_secret access_token).each do |token|
+      %w[client_secret access_token].each do |token|
         url_string.gsub!(/#{token}=\S+/, "#{token}=(redacted)") if url_string.include? token
       end
       url_string

--- a/spec/cassettes/job_log.yml
+++ b/spec/cassettes/job_log.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/191425/jobs/7372c88b-320d-4a2e-bdf8-6e2fc9259fbe/log
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Buildkit v1.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      date:
+      - Fri, 12 May 2017 21:09:38 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      access-control-allow-origin:
+      - "*"
+      access-control-expose-headers:
+      - Link
+      www-authenticate:
+      - Basic realm="api.buildkite.com"
+      cache-control:
+      - no-cache
+      x-request-id:
+      - d661996a-0f88-41db-a338-3e09f0158e55
+      x-runtime:
+      - '0.009931'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-branches/builds/191425/jobs/7372c88b-320d-4a2e-bdf8-6e2fc9259fbe/log",
+          "content": "log entry content",
+          "size": 17
+        }
+    http_version:
+  recorded_at: Fri, 12 May 2017 21:09:36 GMT
+recorded_with: VCR 3.0.3

--- a/spec/client/job_spec.rb
+++ b/spec/client/job_spec.rb
@@ -20,4 +20,14 @@ describe Buildkit::Client::Jobs do
       end
     end
   end
+
+  context '#job_logs' do
+    it 'get the log output of the job' do
+      VCR.use_cassette 'job_log' do
+        job = client.job_log('shopify', 'shopify-branches', 191_425, '7372c88b-320d-4a2e-bdf8-6e2fc9259fbe')
+        expect(job.content).to be == 'log entry content'
+        expect(job.size).to be == 17
+      end
+    end
+  end
 end

--- a/spec/client/organizations_spec.rb
+++ b/spec/client/organizations_spec.rb
@@ -21,7 +21,7 @@ describe Buildkit::Client::Organizations do
         expect(organization.name).to be == 'Shopify'
         expect(organization.slug).to be == 'shopify'
 
-        expect(organization.rels.keys).to be == %i(self web pipelines agents emojis)
+        expect(organization.rels.keys).to be == %i[self web pipelines agents emojis]
       end
     end
   end


### PR DESCRIPTION
This adds `#job_log` to `Buildkit::Client::Jobs` to fetch the log output.