### PR TITLE
Adding auto_paginate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 25
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/BlockLength:
   Enabled: false # RSpec ... :facepalm:
 

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -139,17 +139,17 @@ module Buildkit
       response = []
       loop do
         request method, path, data, options
+        response.concat @last_response.data
+
         link_header = parse_link_header(@last_response.headers[:link])
-        @last_response.data.each { |r| response << r }
-        break if link_header.nil? || link_header[:next].nil?
-        path = next_page(link_header[:next]) if link_header[:next]
+        break if link_header[:next].nil?
+        path = next_page(link_header[:next])
       end
       response
     end
 
     def next_page(next_page)
-      return build_path URI(next_page) unless next_page.nil?
-      nil
+      build_path URI(next_page)
     end
 
     def build_path(uri)

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -136,6 +136,18 @@ module Buildkit
       }
     end
 
+    def parse_link_header(link_header)
+      return unless link_header
+      links = {}
+      link_header.split(',').each do |link|
+        section = link.split(';')
+        url = section[0][/<(.+)>/, 1]
+        name = section[1][/rel="(.*)"/,1].to_sym
+        links[name] = url
+      end
+      links
+    end
+
     def parse_query_and_convenience_headers(options)
       headers = options.fetch(:headers, {})
       CONVENIENCE_HEADERS.each do |h|

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -48,7 +48,7 @@ module Buildkit
     # @param options [Hash] Query and header params for request
     # @return [Sawyer::Resource]
     def get(url, options = {})
-      if options[:all_pages]
+      if options.delete(:all_pages)
         request_all_pages :get, url, parse_query_and_convenience_headers(options)
       else
         request(:get, url, parse_query_and_convenience_headers(options)).data
@@ -100,7 +100,6 @@ module Buildkit
       request(:head, url, parse_query_and_convenience_headers(options)).data
     end
 
-
     # Fetch the root resource for the API
     #
     # @return [Sawyer::Resource]
@@ -123,9 +122,9 @@ module Buildkit
     end
 
     def extract_query_and_headers_from(data)
-      options = {
+      {
         query: data.delete(:query) || {},
-        headers: data.delete(:headers) || {}
+        headers: data.delete(:headers) || {},
       }
     end
 
@@ -136,12 +135,12 @@ module Buildkit
         link_header = parse_link_header(res.headers[:link])
         res.data.each { |r| response << r }
         break if link_header.nil? || link_header[:next].nil?
-        path = next_page(link_header[:next], res) if link_header[:next]
+        path = next_page(link_header[:next]) if link_header[:next]
       end
       response
     end
 
-    def next_page(next_page, res)
+    def next_page(next_page)
       return build_path URI(next_page) unless next_page.nil?
       nil
     end
@@ -170,7 +169,7 @@ module Buildkit
       return unless link_header
       links = {}
       link_header.split(',').each do |link|
-        links = links.merge(parse_link link)
+        links = links.merge(parse_link(link))
       end
       links
     end

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -6,6 +6,7 @@ require 'buildkit/client/pipelines'
 require 'buildkit/client/jobs'
 require 'buildkit/client/artifacts'
 require 'buildkit/response/raise_error'
+require 'buildkit/header_link_parser'
 
 module Buildkit
   class Client
@@ -15,6 +16,7 @@ module Buildkit
     include Pipelines
     include Jobs
     include Artifacts
+    include HeaderLinkParser
 
     DEFAULT_ENDPOINT = 'https://api.buildkite.com/v2/'.freeze
 
@@ -23,6 +25,8 @@ module Buildkit
 
     # In Faraday 0.9, Faraday::Builder was renamed to Faraday::RackBuilder
     RACK_BUILDER_CLASS = defined?(Faraday::RackBuilder) ? Faraday::RackBuilder : Faraday::Builder
+
+    attr_accessor :auto_paginate
 
     class << self
       def build_middleware
@@ -36,10 +40,11 @@ module Buildkit
 
     def initialize(endpoint: ENV.fetch('BUILDKITE_API_ENDPOINT', DEFAULT_ENDPOINT),
                    token: ENV.fetch('BUILDKITE_API_TOKEN'),
-                   middleware: self.class.build_middleware)
+                   middleware: self.class.build_middleware, auto_paginate: false)
       @middleware = middleware
       @endpoint = endpoint
       @token = token
+      @auto_paginate = auto_paginate
     end
 
     # Make a HTTP GET request
@@ -48,10 +53,10 @@ module Buildkit
     # @param options [Hash] Query and header params for request
     # @return [Sawyer::Resource]
     def get(url, options = {})
-      if options.delete(:all_pages)
-        request_all_pages :get, url, parse_query_and_convenience_headers(options)
+      if @auto_paginate
+        paginate :get, url, parse_query_and_convenience_headers(options)
       else
-        request(:get, url, parse_query_and_convenience_headers(options)).data
+        request :get, url, parse_query_and_convenience_headers(options)
       end
     end
 
@@ -61,7 +66,7 @@ module Buildkit
     # @param options [Hash] Body and header params for request
     # @return [Sawyer::Resource]
     def post(url, options = {})
-      request(:post, url, options).data
+      request :post, url, options
     end
 
     # Make a HTTP PUT request
@@ -70,7 +75,7 @@ module Buildkit
     # @param options [Hash] Body and header params for request
     # @return [Sawyer::Resource]
     def put(url, options = {})
-      request(:put, url, options).data
+      request :put, url, options
     end
 
     # Make a HTTP PATCH request
@@ -79,7 +84,7 @@ module Buildkit
     # @param options [Hash] Body and header params for request
     # @return [Sawyer::Resource]
     def patch(url, options = {})
-      request(:patch, url, options).data
+      request :patch, url, options
     end
 
     # Make a HTTP DELETE request
@@ -88,7 +93,7 @@ module Buildkit
     # @param options [Hash] Query and header params for request
     # @return [Sawyer::Resource]
     def delete(url, options = {})
-      request(:delete, url, options).data
+      request :delete, url, options
     end
 
     # Make a HTTP HEAD request
@@ -97,8 +102,10 @@ module Buildkit
     # @param options [Hash] Query and header params for request
     # @return [Sawyer::Resource]
     def head(url, options = {})
-      request(:head, url, parse_query_and_convenience_headers(options)).data
+      request :head, url, parse_query_and_convenience_headers(options)
     end
+
+    attr_reader :last_response
 
     # Fetch the root resource for the API
     #
@@ -117,8 +124,8 @@ module Buildkit
         end
       end
 
-      response = sawyer_agent.call(method, URI::Parser.new.escape(path.to_s), data, options)
-      response
+      @last_response = response = sawyer_agent.call(method, URI::DEFAULT_PARSER.escape(path.to_s), data, options)
+      response.data
     end
 
     def extract_query_and_headers_from(data)
@@ -128,12 +135,12 @@ module Buildkit
       }
     end
 
-    def request_all_pages(method, path, data, options = {})
+    def paginate(method, path, data, options = {})
       response = []
       loop do
-        res = request(method, path, data, options)
-        link_header = parse_link_header(res.headers[:link])
-        res.data.each { |r| response << r }
+        request method, path, data, options
+        link_header = parse_link_header(@last_response.headers[:link])
+        @last_response.data.each { |r| response << r }
         break if link_header.nil? || link_header[:next].nil?
         path = next_page(link_header[:next]) if link_header[:next]
       end
@@ -163,30 +170,6 @@ module Buildkit
         links_parser: Sawyer::LinkParsers::Simple.new,
         faraday: Faraday.new(builder: @middleware),
       }
-    end
-
-    def parse_link_header(link_header)
-      return unless link_header
-      links = {}
-      link_header.split(',').each do |link|
-        links = links.merge(parse_link(link))
-      end
-      links
-    end
-
-    def parse_link(link)
-      section = link.split(';')
-      url = parse_url section[0]
-      name = parse_url_name section[1]
-      {name => url}
-    end
-
-    def parse_url(url)
-      url[/<(.+)>/, 1]
-    end
-
-    def parse_url_name(name)
-      name[/rel="(.*)"/, 1].to_sym
     end
 
     def parse_query_and_convenience_headers(options)

--- a/lib/buildkit/header_link_parser.rb
+++ b/lib/buildkit/header_link_parser.rb
@@ -1,0 +1,26 @@
+module HeaderLinkParser
+  module_function
+
+  def parse_link_header(link_header)
+    {}.tap do |hash_link|
+      link_header.split(',').each do |link|
+        link_obj = LinkParser.new(link)
+        hash_link[link_obj.name] = link_obj.link
+      end
+    end
+  end
+
+  class LinkParser
+    def initialize(value)
+      @value = value
+    end
+
+    def name
+      @name ||= @value[/rel="(.*)"/, 1].to_sym
+    end
+
+    def link
+      @link ||= @value[/<(.+)>/, 1]
+    end
+  end
+end

--- a/spec/buildkit_spec.rb
+++ b/spec/buildkit_spec.rb
@@ -14,6 +14,15 @@ describe Buildkit do
     end
   end
 
+  describe 'client' do
+    it 'has last_response' do
+      VCR.use_cassette 'root' do
+        root = client.root
+        expect(client.last_response.data.response).to eq(root.response)
+      end
+    end
+  end
+
   describe 'errors' do
     it 'raises a Buildkit::NotFound on 404 responses' do
       VCR.use_cassette '404' do

--- a/spec/cassettes/pipelines.yml
+++ b/spec/cassettes/pipelines.yml
@@ -18,7 +18,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       server:
       - nginx/1.6.3
@@ -195,6 +195,322 @@ http_interactions:
             "running_jobs_count": 0
           }
         ]
-    http_version: 
+    http_version:
+  recorded_at: Thu, 23 Apr 2015 17:11:58 GMT
+- request:
+    method: get
+    uri: https://api.buildkite.com/v2/organizations/shopify/pipelines
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Buildkit v0.1.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.6.3
+      date:
+      - Thu, 23 Apr 2015 17:11:58 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN, SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff, nosniff
+      access-control-allow-origin:
+      - "*"
+      x-accepted-oauth-scopes:
+      - read_pipelines
+      link:
+      - <https://api.buildkite.com/v2/organizations/shopify/pipelines?page=2>;
+        rel="next", <https://api.buildkite.com/v2/organizations/shopify/pipelines?page=2>;
+        rel="last"
+      x-oauth-scopes:
+      - read_user,read_organizations,read_pipelines,write_pipelines,read_builds,write_builds,read_build_logs,read_agents,write_agents
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 3a5a6577-528b-4390-ad35-cf6819b1c6d9
+      x-runtime:
+      - '0.041574'
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-ua-compatible:
+      - chrome=1
+    body:
+      encoding: UTF-8
+      string: |
+        [
+          {
+            "id": "5c6894bc-948c-4423-b536-987fd0332912",
+            "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-borgified",
+            "web_url": "https://buildkite.com/shopify/shopify-borgified",
+            "name": "shopify-borgified",
+            "slug": "shopify-borgified",
+            "repository": "git@github.com:Shopify/shopify.git",
+            "provider": {
+              "id": "github",
+              "webhook_url": "https://webhook.buildkite.com/deliver/597fb5587a1da3b36b7abb0050e3ad6650b514138991d7053f"
+            },
+            "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-borgified/builds",
+            "created_at": "2015-04-21 14:44:26 UTC",
+            "steps": [
+              {
+                "type": "script",
+                "name": "wait-for-container",
+                "command": "buildkite/wait-for-container.sh",
+                "artifact_paths": "",
+                "branch_configuration": "",
+                "env": {
+                },
+                "timeout_in_minutes": 10,
+                "agent_query_rules": [
+                  "docker=1"
+                ]
+              },
+              {
+                "type": "waiter"
+              },
+              {
+                "type": "script",
+                "name": "tests-%n",
+                "command": "buildkite/run-tests.rb",
+                "artifact_paths": ".artifacts/**/*;/app/logs/**/*",
+                "branch_configuration": "",
+                "env": {
+                },
+                "timeout_in_minutes": null,
+                "agent_query_rules": [
+                  "docker=1"
+                ]
+              }
+            ],
+            "env": {
+              "RUBY_GC_MALLOC_LIMIT": "128000000",
+              "RUBY_GC_OLDMALLOC_LIMIT": "128000000",
+              "RUBY_GC_HEAP_GROWTH_FACTOR": "1.25",
+              "RUBY_GC_HEAP_GROWTH_MAX_SLOTS": "300000",
+              "RUBY_GC_HEAP_INIT_SLOTS": "600000",
+              "RUBY_GC_HEAP_FREE_SLOTS": "600000"
+            },
+            "featured_build": {
+              "id": "500713d1-8aa3-46d4-a58a-d6a795056c6d",
+              "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-borgified/builds/68",
+              "web_url": "https://buildkite.com/shopify/shopify-borgified/builds/68",
+              "number": 68,
+              "state": "failed",
+              "message": "sudo mount -o remount,rw,noatime,nobarrier /dev/md0 /u",
+              "commit": "HEAD",
+              "branch": "bk-tar-no-compress",
+              "env": {
+              },
+              "created_at": "2015-04-23 16:55:52 UTC",
+              "scheduled_at": "2015-04-23 16:55:52 UTC",
+              "started_at": "2015-04-23 16:55:58 UTC",
+              "finished_at": "2015-04-23 17:03:21 UTC",
+              "meta_data": {
+                "buildkite:git:branch": "* master",
+                "buildkite:git:commit": "commit 98e2f4eeabbfd6c9f29ba23b2a9c74311fd8682a\nAuthor:     Anonymous <anonymous@example.com>\nAuthorDate: Thu Apr 23 11:24:38 2015 -0400\nCommit:     Anonymous <anonymous@example.com>\nCommitDate: Thu Apr 23 11:24:38 2015 -0400\n\n    More semian tickets"
+              }
+            },
+            "scheduled_builds_count": 0,
+            "running_builds_count": 0,
+            "scheduled_jobs_count": 0,
+            "running_jobs_count": 0
+          },
+          {
+            "id": "4c47bc4e-03cc-49dd-9f7f-0b7e986f77bb",
+            "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone",
+            "web_url": "https://buildkite.com/shopify/shopify-for-iphone",
+            "name": "Shopify for iPhone",
+            "slug": "shopify-for-iphone",
+            "repository": "git@github.com:Shopify/shopify-ios-admin.git",
+            "provider": {
+              "id": "github",
+              "webhook_url": "https://webhook.buildkite.com/deliver/2452a4d474037955a2e9f9078985a40900d9184cdb1949639f"
+            },
+            "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone/builds",
+            "created_at": "2015-04-20 20:21:41 UTC",
+            "steps": [
+              {
+                "type": "script",
+                "name": "Build and Test",
+                "command": "buildkite/develop.sh",
+                "artifact_paths": "",
+                "branch_configuration": "",
+                "env": {
+                },
+                "timeout_in_minutes": null,
+                "agent_query_rules": [
+                  "mac=true"
+                ]
+              }
+            ],
+            "env": {
+            },
+            "featured_build": {
+              "id": "00f2a763-86c8-4597-a290-2e5f55e3c3e6",
+              "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone/builds/39",
+              "web_url": "https://buildkite.com/shopify/shopify-for-iphone/builds/39",
+              "number": 39,
+              "state": "failed",
+              "message": "Merge pull request #1956 from Shopify/bugfix/watch-operations\n\nFixes the watch operations which stopped executing on Xcode 6.3",
+              "commit": "f800c90ffd5d89528546d724063251b2d922c298",
+              "branch": "release/4.5.1",
+              "env": {
+              },
+              "created_at": "2015-04-23 16:53:11 UTC",
+              "scheduled_at": "2015-04-23 16:53:11 UTC",
+              "started_at": "2015-04-23 16:53:16 UTC",
+              "finished_at": "2015-04-23 16:57:34 UTC",
+              "meta_data": {
+                "buildkite:git:branch": "* (detached from f73f346)",
+                "buildkite:git:commit": "commit f800c90ffd5d89528546d724063251b2d922c298\nMerge: 5fc0835 f73f346\nAuthor:     Anonymous <anonymous@example.com>\nAuthorDate: Thu Apr 23 12:53:11 2015 -0400\nCommit:     Anonymous <anonymous@example.com>\nCommitDate: Thu Apr 23 12:53:11 2015 -0400\n\n    Merge pull request #1956 from Shopify/bugfix/watch-operations\n    \n    Fixes the watch operations which stopped executing on Xcode 6.3"
+              }
+            },
+            "scheduled_builds_count": 0,
+            "running_builds_count": 0,
+            "scheduled_jobs_count": 0,
+            "running_jobs_count": 0
+          }
+        ]
+    http_version:
+  recorded_at: Thu, 23 Apr 2015 17:11:58 GMT
+- request:
+    method: get
+    uri: https://api.buildkite.com/v2/organizations/shopify/pipelines?page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Buildkit v0.1.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.6.3
+      date:
+      - Thu, 23 Apr 2015 17:11:58 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN, SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff, nosniff
+      access-control-allow-origin:
+      - "*"
+      x-accepted-oauth-scopes:
+      - read_pipelines
+      link:
+      - <https://api.buildkite.com/v2/organizations/shopify/pipelines?page=2>;
+        rel="last"
+      x-oauth-scopes:
+      - read_user,read_organizations,read_pipelines,write_pipelines,read_builds,write_builds,read_build_logs,read_agents,write_agents
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 3a5a6577-528b-4390-ad35-cf6819b1c6d9
+      x-runtime:
+      - '0.041574'
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains
+      x-ua-compatible:
+      - chrome=1
+    body:
+      encoding: UTF-8
+      string: |
+        [
+          {
+            "id": "4c47bc4e-03cc-49dd-9f7f-0b7e986f77bb",
+            "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone",
+            "web_url": "https://buildkite.com/shopify/shopify-for-iphone",
+            "name": "pipeline from the second page",
+            "slug": "shopify-for-iphone",
+            "repository": "git@github.com:Shopify/shopify-ios-admin.git",
+            "provider": {
+              "id": "github",
+              "webhook_url": "https://webhook.buildkite.com/deliver/2452a4d474037955a2e9f9078985a40900d9184cdb1949639f"
+            },
+            "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone/builds",
+            "created_at": "2015-04-20 20:21:41 UTC",
+            "steps": [
+              {
+                "type": "script",
+                "name": "Build and Test",
+                "command": "buildkite/develop.sh",
+                "artifact_paths": "",
+                "branch_configuration": "",
+                "env": {
+                },
+                "timeout_in_minutes": null,
+                "agent_query_rules": [
+                  "mac=true"
+                ]
+              }
+            ],
+            "env": {
+            },
+            "featured_build": {
+              "id": "00f2a763-86c8-4597-a290-2e5f55e3c3e6",
+              "url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone/builds/39",
+              "web_url": "https://buildkite.com/shopify/shopify-for-iphone/builds/39",
+              "number": 39,
+              "state": "failed",
+              "message": "Merge pull request #1956 from Shopify/bugfix/watch-operations\n\nFixes the watch operations which stopped executing on Xcode 6.3",
+              "commit": "f800c90ffd5d89528546d724063251b2d922c298",
+              "branch": "release/4.5.1",
+              "env": {
+              },
+              "created_at": "2015-04-23 16:53:11 UTC",
+              "scheduled_at": "2015-04-23 16:53:11 UTC",
+              "started_at": "2015-04-23 16:53:16 UTC",
+              "finished_at": "2015-04-23 16:57:34 UTC",
+              "meta_data": {
+                "buildkite:git:branch": "* (detached from f73f346)",
+                "buildkite:git:commit": "commit f800c90ffd5d89528546d724063251b2d922c298\nMerge: 5fc0835 f73f346\nAuthor:     Anonymous <anonymous@example.com>\nAuthorDate: Thu Apr 23 12:53:11 2015 -0400\nCommit:     Anonymous <anonymous@example.com>\nCommitDate: Thu Apr 23 12:53:11 2015 -0400\n\n    Merge pull request #1956 from Shopify/bugfix/watch-operations\n    \n    Fixes the watch operations which stopped executing on Xcode 6.3"
+              }
+            },
+            "scheduled_builds_count": 0,
+            "running_builds_count": 0,
+            "scheduled_jobs_count": 0,
+            "running_jobs_count": 0
+          }
+        ]
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:11:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/cassettes/pipelines.yml
+++ b/spec/cassettes/pipelines.yml
@@ -71,7 +71,7 @@ http_interactions:
             "repository": "git@github.com:Shopify/shopify.git",
             "provider": {
               "id": "github",
-              "webhook_url": "https://webhook.buildkite.com/deliver/597fb5587a1da3b36b7abb0050e3ad6650b514138991d7053f"
+              "webhook_url": "htpps://webhook.buildkite.com/deliver/12345abcdef"
             },
             "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-borgified/builds",
             "created_at": "2015-04-21 14:44:26 UTC",
@@ -148,7 +148,7 @@ http_interactions:
             "repository": "git@github.com:Shopify/shopify-ios-admin.git",
             "provider": {
               "id": "github",
-              "webhook_url": "https://webhook.buildkite.com/deliver/2452a4d474037955a2e9f9078985a40900d9184cdb1949639f"
+              "webhook_url": "htpps://webhook.buildkite.com/deliver/12345abcdef"
             },
             "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone/builds",
             "created_at": "2015-04-20 20:21:41 UTC",
@@ -268,7 +268,7 @@ http_interactions:
             "repository": "git@github.com:Shopify/shopify.git",
             "provider": {
               "id": "github",
-              "webhook_url": "https://webhook.buildkite.com/deliver/597fb5587a1da3b36b7abb0050e3ad6650b514138991d7053f"
+              "webhook_url": "htpps://webhook.buildkite.com/deliver/12345abcdef"
             },
             "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-borgified/builds",
             "created_at": "2015-04-21 14:44:26 UTC",
@@ -345,7 +345,7 @@ http_interactions:
             "repository": "git@github.com:Shopify/shopify-ios-admin.git",
             "provider": {
               "id": "github",
-              "webhook_url": "https://webhook.buildkite.com/deliver/2452a4d474037955a2e9f9078985a40900d9184cdb1949639f"
+              "webhook_url": "htpps://webhook.buildkite.com/deliver/12345abcdef"
             },
             "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone/builds",
             "created_at": "2015-04-20 20:21:41 UTC",
@@ -464,7 +464,7 @@ http_interactions:
             "repository": "git@github.com:Shopify/shopify-ios-admin.git",
             "provider": {
               "id": "github",
-              "webhook_url": "https://webhook.buildkite.com/deliver/2452a4d474037955a2e9f9078985a40900d9184cdb1949639f"
+              "webhook_url": "htpps://webhook.buildkite.com/deliver/12345abcdef"
             },
             "builds_url": "https://api.buildkite.com/v2/organizations/shopify/pipelines/shopify-for-iphone/builds",
             "created_at": "2015-04-20 20:21:41 UTC",

--- a/spec/client/pipelines_spec.rb
+++ b/spec/client/pipelines_spec.rb
@@ -11,6 +11,33 @@ describe Buildkit::Client::Pipelines do
         expect(pipeline.name).to be == 'shopify-borgified'
       end
     end
+
+    it 'returns all pipelines if all_pages is true' do
+      VCR.use_cassette 'pipelines' do
+        pipelines = client.pipelines('shopify', all_pages: true)
+        expect(pipelines.size).to be == 3
+
+        pipeline = pipelines.first
+        expect(pipeline.name).to eq 'shopify-borgified'
+
+        pipeline = pipelines.last
+        expect(pipeline.name).to eq 'pipeline from the second page'
+      end
+    end
+
+    it 'returns first page if all_pages is false' do
+      VCR.use_cassette 'pipelines' do
+
+        pipelines = client.pipelines('shopify')
+        expect(pipelines.size).to be == 2
+
+        pipeline = pipelines.first
+        expect(pipeline.name).to eq 'shopify-borgified'
+
+        pipeline = pipelines.last
+        expect(pipeline.name).to eq 'Shopify for iPhone'
+      end
+    end
   end
 
   context '#pipeline' do

--- a/spec/client/pipelines_spec.rb
+++ b/spec/client/pipelines_spec.rb
@@ -12,9 +12,11 @@ describe Buildkit::Client::Pipelines do
       end
     end
 
-    it 'returns all pipelines if all_pages is true' do
+    it 'returns all pipelines if auto_paginate is true' do
       VCR.use_cassette 'pipelines' do
-        pipelines = client.pipelines('shopify', all_pages: true)
+        client.auto_paginate = true
+
+        pipelines = client.pipelines('shopify')
         expect(pipelines.size).to be == 3
 
         pipeline = pipelines.first
@@ -25,9 +27,8 @@ describe Buildkit::Client::Pipelines do
       end
     end
 
-    it 'returns first page if all_pages is false' do
+    it 'returns first page if auto_paginate is false' do
       VCR.use_cassette 'pipelines' do
-
         pipelines = client.pipelines('shopify')
         expect(pipelines.size).to be == 2
 


### PR DESCRIPTION
### Problem:
Currently the gem only fetches the first page for pipelines from buildkite. Each page has 30 pipelines.

### Solution:
if `auto_paginate` is set or passed as true then follow the next page from the header link
```ruby
client = Buildkit.new token: 'SomeRandomToken'
client.auto_paginate = true
pipelines = client.pipelines 'org'
pipelines.count
# => 31
```

_**NOTE:** Travis ci is falling because of rubocop. This PR #16 should fix it._