### PR TITLE
fixing rubocop and style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,10 @@ Style/PerlBackrefs:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInArguments:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 Metrics/LineLength:
   Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 before_install: gem install bundler
 rvm:
-  - '2.1'
   - '2.2'
+  - '2.3'
 

--- a/buildkit.gemspec
+++ b/buildkit.gemspec
@@ -1,6 +1,4 @@
-# coding: utf-8
-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'buildkit/version'
 
@@ -19,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency 'sawyer', '~> 0.6'
   spec.add_development_dependency 'bundler'

--- a/buildkit.gemspec
+++ b/buildkit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency 'sawyer', '~> 0.6'
   spec.add_development_dependency 'bundler'

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -116,12 +116,12 @@ module Buildkit
         end
       end
 
-      @last_response = response = sawyer_agent.call(method, URI::Parser.new.escape(path.to_s), data, options)
+      @last_response = response = sawyer_agent.call(method, URI::DEFAULT_PARSER.escape(path.to_s), data, options)
       response.data
     end
 
     def sawyer_agent
-      @agent ||= Sawyer::Agent.new(@endpoint, sawyer_options) do |http|
+      @sawyer_agent ||= Sawyer::Agent.new(@endpoint, sawyer_options) do |http|
         http.headers[:accept] = 'application/json'
         http.headers[:content_type] = 'application/json'
         http.headers[:user_agent] = "Buildkit v#{Buildkit::VERSION}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ VCR.configure do |config|
   end
 end
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'buildkit'
 
 module TestClient


### PR DESCRIPTION
Fixing rubocop.yml and code style `rubocop -a`. Currently travis CI is failing on master because of rubocop.