### PR TITLE
Fix pagination.

### DIFF
--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -139,6 +139,10 @@ module Buildkit
       response = []
       loop do
         request method, path, data, options
+
+        # Paginated API calls always return Arrays.
+        return last_response.data unless @last_response.data.is_a?(Array)
+
         response.concat @last_response.data
 
         link_header = parse_link_header(@last_response.headers[:link])

--- a/spec/client/builds_spec.rb
+++ b/spec/client/builds_spec.rb
@@ -50,6 +50,17 @@ describe Buildkit::Client::Builds do
     end
   end
 
+  context '#paginated_build' do
+    it 'returns the build' do
+      VCR.use_cassette 'build' do
+        client.auto_paginate = true
+        build = client.build('shopify', 'shopify-borgified', 68)
+        expect(build.number).to be == 68
+        expect(build.state).to be == 'failed'
+      end
+    end
+  end
+
   context '#rebuild' do
     it 'rebuilds the build' do
       VCR.use_cassette 'rebuild' do


### PR DESCRIPTION
`Client#paginate` expects the returned `data` to be an Array, but non-paginated API calls (e.g. `build`) return only a Resource object.

Another way to fix this would be to have paginated (or non-paginated) calls explicitly identify themselves as such, rather than having the `paginate` call determine this based on the class of the returned `data`, but this might be annoying to maintain.