### PR TITLE
Fix FrozenError

### DIFF
--- a/lib/buildkit/error.rb
+++ b/lib/buildkit/error.rb
@@ -100,7 +100,7 @@ module Buildkit
     def build_error_message
       return nil if @response.nil?
 
-      message = "#{@response[:method].to_s.upcase} #{redact_url(@response[:url].to_s)}: #{@response[:status]} - "
+      message = +"#{@response[:method].to_s.upcase} #{redact_url(@response[:url].to_s)}: #{@response[:status]} - "
       message << "#{response_message}#{response_error}#{response_error_summary}"
       message << " // See: #{documentation_url}" unless documentation_url.nil?
       message


### PR DESCRIPTION
This fixes:

```
	 7: from /Users/kirs/.gem/ruby/2.5.5/gems/faraday-0.15.4/lib/faraday/response.rb:8:in `call'
	 6: from /Users/kirs/.gem/ruby/2.5.5/gems/faraday-0.15.4/lib/faraday/response.rb:61:in `on_complete'
	 5: from /Users/kirs/.gem/ruby/2.5.5/gems/faraday-0.15.4/lib/faraday/response.rb:9:in `block in call'
	 4: from /Users/kirs/src/github.com/Shopify/buildkit/lib/buildkit/response/raise_error.rb:15:in `on_complete'
	 3: from /Users/kirs/src/github.com/Shopify/buildkit/lib/buildkit/error.rb:30:in `from_response'
	 2: from /Users/kirs/src/github.com/Shopify/buildkit/lib/buildkit/error.rb:30:in `new'
	 1: from /Users/kirs/src/github.com/Shopify/buildkit/lib/buildkit/error.rb:36:in `initialize'
/Users/kirs/src/github.com/Shopify/buildkit/lib/buildkit/error.rb:104:in `build_error_message': can't modify frozen String (FrozenError)
```

I hit it locally when invoking Buildkit from a script. I'm not sure what would be the right way to test it though 🤔 