### PR TITLE
gemspec: Loosen sawyer dependency / fix faraday response middleware issue / TravisCI -> Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+on: push
+name: Test Buildkit Gem
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby: [ '2.5', '2.6', '2.7' ]
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: bundle install
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+      - name: Run rspec
+        run: 'bundle exec rspec spec'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-sudo: false
-before_install: gem install bundler
-rvm:
-  - '2.5'

--- a/buildkit.gemspec
+++ b/buildkit.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'sawyer', '~> 0.6'
+  spec.add_dependency 'sawyer', '>= 0.6'
   spec.add_development_dependency 'bundler'
 end

--- a/dev.yml
+++ b/dev.yml
@@ -3,8 +3,6 @@ name: buildkit
 type: ruby
 
 up:
-  - homebrew:
-    - openssl
   - ruby: 2.5.5
   - bundler
 

--- a/lib/buildkit/response/raise_error.rb
+++ b/lib/buildkit/response/raise_error.rb
@@ -9,8 +9,6 @@ module Buildkit
     # This class raises an Buildkit-flavored exception based
     # HTTP status codes returned by the API
     class RaiseError < Faraday::Response::Middleware
-      private
-
       def on_complete(response)
         if error = Buildkit::Error.from_response(response)
           raise error


### PR DESCRIPTION
This PR bumps the sawyer dep to allow versions greater than `0.6`, since other gems such as `octokit` use `0.8.3`, causing bundler to complain about a version conflict. 

Other fixes:
- dev.yml - removed homebrew openssl clause since it is deprecated
- Fix issue where Buildkit errors does not raise a Buildkit::NotFound on 404 responses (tested on Faraday 1.3.0)
- Move to Github Actions because travisci.org is dead