### PR TITLE
Release 1.4.2

### DIFF
--- a/lib/buildkit/version.rb
+++ b/lib/buildkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Buildkit
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end


### PR DESCRIPTION
This bumps the version number to 1.4.2, so we can cut a new release. 