### PR TITLE
gemspec: Set allowed_push_host to rubygems.org

### DIFF
--- a/buildkit.gemspec
+++ b/buildkit.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.metadata['allowed_push_host'] = "http://rubygems.org"
+
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'sawyer', '>= 0.6'


### PR DESCRIPTION
Cutting a new release and trying to push to rubygems.org failed due to a missing `allowed_push_host` attribute in the gemspec. This PR adds that missing attribute in. 