### PR TITLE
Fix deprecation warning in ruby 2.7

### DIFF
--- a/lib/buildkit.rb
+++ b/lib/buildkit.rb
@@ -4,7 +4,7 @@ require 'buildkit/version'
 require 'buildkit/client'
 
 module Buildkit
-  def self.new(*args)
-    Client.new(*args)
+  def self.new(*args, **kwargs)
+    Client.new(**kwargs)
   end
 end


### PR DESCRIPTION
Prior to this change, the following deprecation warning shows when instantiating a new client:

```
buildkit/lib/buildkit.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
buildkit/lib/buildkit/client.rb:43: warning: The called method `initialize' is defined here
```

I developed the fix based on the example under "Ruby 3" at https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This change seems to work for each of the following cases:

```
client = Buildkit.new(token: ENV["BUILDKITE_API_TOKEN"])
client = Buildkit.new(token: "my-secret-token")
client = Buildkit.new
```

I am by no means a ruby aficionado, so please take this change with a grain of salt 🙏  