### PR TITLE
Unescape URI so `:` character is correctly propagated.

### DIFF
--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -150,7 +150,8 @@ module Buildkit
         link_header = parse_link_header(@last_response.headers[:link])
         break if link_header[:next].nil?
 
-        path = next_page(link_header[:next])
+        unescaped_next = CGI.unescape(link_header[:next])
+        path = next_page(unescaped_next)
       end
       response
     end
@@ -160,7 +161,7 @@ module Buildkit
     end
 
     def build_path(uri)
-      CGI.unescape("#{uri.path}?#{uri.query}")
+      "#{uri.path}?#{uri.query}"
     end
 
     def sawyer_agent

--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -160,7 +160,7 @@ module Buildkit
     end
 
     def build_path(uri)
-      "#{uri.path}?#{uri.query}"
+      CGI.unescape("#{uri.path}?#{uri.query}")
     end
 
     def sawyer_agent


### PR DESCRIPTION
Paginated results fail when auto paginated is enabled, and a date is passed in the parameters.
This is because the next page is retrieved from the previous response and is [not escaped before issuing the next request](https://github.com/Shopify/buildkit/blob/03c76b169a9965df843d4d3a5bde3cf6d8446f90/lib/buildkit/client.rb#L153), thus percent encoding is still present.

Example code: 
```
    client = Buildkit.new(token: TOKEN)
    client.auto_paginate = true
    time = DateTime.now - 1

    params = { created_from: time, per_page: 1}

    builds = client.organization_builds(ORG_NAME, params)
```

Running the above, when more than one build is found, you would retrieve an error similar to the following.

```
field: created_from
  code: Created from is not a valid date: "2021-04-27T09%3A30%3A15-07%3A00"
  value: 2021-04-27T09%3A30%3A15-07%3A00
 ```

To solve this, we can simply unescape the created `path` when retrieving the details for the next page.