### PR TITLE
Fix pagination when there are no extra pages to fetch

### DIFF
--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -147,6 +147,7 @@ module Buildkit
 
         response.concat @last_response.data
 
+        break if @last_response.headers[:link].nil?
         link_header = parse_link_header(@last_response.headers[:link])
         break if link_header[:next].nil?
 


### PR DESCRIPTION
From the 17th August, I have noticed responses from the Buildkite API which do not contain the Link HTTP response header. It seems the header is now only added if there are extra pages available. 

This became an issue when auto paginating in the repo because it expects there is always a Link HTTP response header, and attempts to split the value without check it's validity beforehand. 

This PR fixes the issue by check if the Link HTTP response header is present prior to parsing. 