### PR TITLE
Fix: stop deprecation warnings from Faraday >1.7.1

### DIFF
--- a/lib/buildkit/client.rb
+++ b/lib/buildkit/client.rb
@@ -170,7 +170,11 @@ module Buildkit
         http.headers[:accept] = 'application/json'
         http.headers[:content_type] = 'application/json'
         http.headers[:user_agent] = "Buildkit v#{Buildkit::VERSION}"
-        http.authorization 'Bearer', @token
+        if Gem::Version.new(Faraday::VERSION) >= Gem::Version.new("1.7.1")
+          http.request :authorization, 'Bearer', @token
+        else
+          http.authorization 'Bearer', @token
+        end
       end
     end
 


### PR DESCRIPTION
eg:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```