### PR TITLE
Patch upgrade 1.4.5 to 1.4.6, to remove deprecation warnings from Faraday

### DIFF
--- a/lib/buildkit/version.rb
+++ b/lib/buildkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Buildkit
-  VERSION = '1.4.5'
+  VERSION = '1.4.6'
 end


### PR DESCRIPTION
Patch version upgrade so we have a version containing [this](https://github.com/Shopify/buildkit/commit/04dfda2da91e9106e2da8fd392a4d756da9594ab) commit. 

Run `bundle exec rake release` after merge.