### PR TITLE
Use non-deprecated Faraday class

### DIFF
--- a/lib/buildkit/response/raise_error.rb
+++ b/lib/buildkit/response/raise_error.rb
@@ -8,7 +8,7 @@ module Buildkit
   module Response
     # This class raises an Buildkit-flavored exception based
     # HTTP status codes returned by the API
-    class RaiseError < Faraday::Response::Middleware
+    class RaiseError < Faraday::Middleware
       def on_complete(response)
         if error = Buildkit::Error.from_response(response)
           raise error


### PR DESCRIPTION
Was getting some Faraday deprecation errors in CI. Updated the `raise_error` class to fix it.
We can see now for Ruby 2.5 it's using Faraday 1.10.0 and works fine, and for 2.6 and above it also works.
https://github.com/lostisland/faraday/blob/main/CHANGELOG.md#200-2022-01-04
https://github.com/lostisland/faraday/blob/main/UPGRADING.md#other

![ruby-2 5](https://user-images.githubusercontent.com/4118969/155593025-a7269f9d-1908-49c6-abac-7b3213c3b686.png)
![ruby-2 6](https://user-images.githubusercontent.com/4118969/155593027-2bcf7fcd-e499-4350-b855-4992154dcc5b.png)
![ruby-3 1](https://user-images.githubusercontent.com/4118969/155593030-b0d71476-c615-485f-89e3-bdc66de0ffd2.png)
s