### PR TITLE
add ruby 3.2 and ruby 3.3 to the github actions test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Changes
- Update github actions test matrix to include ruby 3.2 and 3.3

## Demo
- [CI running on ruby 3.2](https://github.com/Invoca/buildkit/actions/runs/8145394470/job/22261546285) ✅ 
- [CI running on ruby 3.3](https://github.com/Invoca/buildkit/actions/runs/8145394470/job/22261546519) ✅ 